### PR TITLE
Fix mag filter in mipmap sample

### DIFF
--- a/samples/tutorials/Mipmapping/jni/Texture.cpp
+++ b/samples/tutorials/Mipmapping/jni/Texture.cpp
@@ -52,7 +52,7 @@ void loadTexture( const char * texture, unsigned int level, unsigned int width, 
 
     /* Set the filtering mode. */
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST_MIPMAP_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
     free(theTexture);
 }
@@ -91,7 +91,7 @@ void loadCompressedTexture( const char * texture, unsigned int level)
 
     /* Set the filtering mode. */
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST_MIPMAP_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
     free(theTexture);
     fclose(theFile);


### PR DESCRIPTION
Fix small typo in mipmap sample:

GL_NEAREST_MIPMAP_NEAREST is not a valid texture parameter for GL_TEXTURE_MAG_FILTER,
it is only valid with GL_TEXTURE_MIN_FILTER.